### PR TITLE
Adding API diff workflow

### DIFF
--- a/.github/workflows/api_diff.yml
+++ b/.github/workflows/api_diff.yml
@@ -1,0 +1,65 @@
+name: API Diff
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+    inputs:
+      new:
+        description: 'Branch/tag of the new/updated version'
+        required: true
+      old:
+        description: 'Branch/tag of the old/comparison version'
+        required: true
+      
+jobs:
+
+  build:
+    runs-on: macos-14
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Select latest Xcode
+      uses: maxim-lobanov/setup-xcode@v1
+      with:
+        xcode-version: '16.1'
+        
+    - name: 🚚 Fetch repo
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: 👾 Define Diff Versions
+      run: |
+        NEW="${{ env.source }}~${{ env.headGithubRepo }}"
+        OLD="${{ env.target }}~${{ env.baseGithubRepo }}"
+        
+        # Release branches get compared to the last tag instead of the target branch
+        # shellcheck disable=SC2193
+        if [[ "${{ env.targetBranchName || env.noTargetBranch }}" == release/* ]]
+        then
+            LATEST_TAG="$(git describe --tags --abbrev=0)"
+            OLD="$LATEST_TAG~${{ env.githubRepo }}"
+        fi
+        
+        # Providing the output to the environment
+        echo "OLD_VERSION=$OLD" >> "$GITHUB_ENV"
+        echo "NEW_VERSION=$NEW" >> "$GITHUB_ENV"
+      env:
+        source: '${{ github.event.inputs.new || github.head_ref }}'
+        target: '${{ github.event.inputs.old || github.event.pull_request.base.ref }}'
+        githubRepo: '${{github.server_url}}/${{github.repository}}.git'
+        headGithubRepo: '${{github.server_url}}/${{ github.event.pull_request.head.repo.full_name || github.repository}}.git'
+        baseGithubRepo: '${{github.server_url}}/${{github.repository}}.git'
+        noTargetBranch: 'empty_branch'
+        targetBranchName: '${{ github.head_ref }}'
+
+    # The github action automatically posts on a PR (if it's not a fork-PR)
+    # and/or outputs the diff to the $GITHUB_STEP_SUMMARY
+    - name: 🔍 Detect Changes
+      uses: Adyen/adyen-swift-public-api-diff@use-correct-pwd
+      with:
+        platform: "iOS"
+        new: ${{ env.NEW_VERSION }}
+        old: ${{ env.OLD_VERSION }}


### PR DESCRIPTION
### Motivation
I'd like to suggest adding this workflow that generates a human readable public api diff and - once merged - adds it as an auto-updating comment to every future pull request.

I hope this might helpful to you and allows easier detection of public interface changes in the future.

### Description
- Adds a new workflow `api_diff.yml` that creates a public API diff between the head and the base branch